### PR TITLE
update paths to avoid need for sudo

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -195,7 +195,7 @@ var daemon = function(config) {
 			enumerable: false,
 			writable: true,
 			configurable: false,
-			value: p.join(process.env.HOME, '/Library/LaunchDaemons')
+			value: p.join(process.env.HOME, '/Library/LaunchAgents')
 		},
 
 		/**


### PR DESCRIPTION
These changes remove the need to use sudo when installing/uninstalling service
- Changed `root` to users launch agents `/Users/<USER_NAME>/Library/LaunchAgents`
- Changed `logpath` to users log dir `/Users/<USER_NAME>/Library/Logs`
