### PR TITLE
Fix daemon directory path for Node 6.x

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -123,7 +123,7 @@ var daemon = function(config) {
       enumerable: false,
       writable: true,
       configurable: false,
-      value: config.cwd || p.dirname(this.script)
+      value: config.cwd || p.dirname( ( this.script === undefined ) || ( this.script === null ) ) ? '' : this.script.toString() )
     },
 
     /**


### PR DESCRIPTION
Ensures that the daemon directory name path is always a string even if undefined, null, or a non-string type.