### PR TITLE
Fix missing callback DeprecationWarnings while keeping consistent

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -435,7 +435,7 @@ var daemon = function(config) {
 			value: function(callback){
 				var me = this;
 				exec('launchctl load '+this.plist,{},function(){
-					fs.appendFile(me.outlog,'\n'+new Date().toLocaleString()+' - '+me.name+' Started');
+					fs.appendFileSync(me.outlog,'\n'+new Date().toLocaleString()+' - '+me.name+' Started');
 					me.emit('start');
 					callback && callback();
 				});
@@ -454,7 +454,7 @@ var daemon = function(config) {
 			value: function(callback){
 				var me = this;
 				exec('launchctl unload '+this.plist,{},function(){
-					fs.appendFile(me.outlog,'\n'+new Date().toLocaleString()+' - '+me.name+' Stopped');
+					fs.appendFileSync(me.outlog,'\n'+new Date().toLocaleString()+' - '+me.name+' Stopped');
 					me.emit('stop');
 					callback && callback();
 				});


### PR DESCRIPTION
Hello!

This 2 liner solves warning messages in Node 7. The alternative is to add noop callbacks.
It should conform to your contribution guidelines.  If not, let me know :)
I hope that helps!