### PR TITLE
cwd not set to baseDir of script

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -123,7 +123,7 @@ var daemon = function(config) {
       enumerable: false,
       writable: true,
       configurable: false,
-      value: config.cwd || p.dirname( ( ( this.script === undefined ) || ( this.script === null ) ) ? '' : this.script.toString() )
+      value: config.cwd || p.dirname( ( ( config.script === undefined ) || ( config.script === null ) ) ? '' : config.script.toString() )
     },
 
     /**


### PR DESCRIPTION
cwd value checks for `this.script` which is undefined at the time resulting in an empty string being passed to `path.dirname()` and it returns '.' instead of the script directory