### PR TITLE
feat: add runAsUserAgent option

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -21,13 +21,21 @@
  */
 var plist = require('plist'),
 	fs = require('fs'),
+	os = require('os'),
 	p = require('path'),
 	exec = require('child_process').exec,
 	wrapper = p.resolve(p.join(__dirname,'./wrapper.js'));
 
 var daemon = function(config) {
 
-	config.runAsAgent = config.hasOwnProperty('runAsAgent') ? config.runAsAgent: false;
+	config.runAsUserAgent = config.hasOwnProperty('runAsUserAgent') ? config.runAsUserAgent: false;
+	if (config.runAsUserAgent) {
+		config.runAsAgent = true;
+	} else {
+		config.runAsAgent = config.hasOwnProperty('runAsAgent') ? config.runAsAgent: false;
+	}
+
+	const libPath = config.runAsUserAgent ? p.resolve(os.homedir(), 'Library') : '/Library'
 
 	Object.defineProperties(this,{
 
@@ -190,14 +198,14 @@ var daemon = function(config) {
       enumerable: true,
       writable: true,
       configurable: false,
-      value: config.script !== undefined ? require('path').resolve(config.script) : null
+      value: config.script !== undefined ? p.resolve(config.script) : null
     },
 
 		root: {
 			enumerable: false,
 			writable: true,
 			configurable: false,
-			value: config.runAsAgent ? '/Library/LaunchAgents' : '/Library/LaunchDaemons'
+			value: config.runAsAgent ? `${libPath}/LaunchAgents` : `${libPath}/LaunchDaemons`
 		},
 
 		/**
@@ -208,7 +216,7 @@ var daemon = function(config) {
 			enumerable: true,
 			writable: true,
 			configurable: false,
-			value: config.logpath || '/Library/Logs/'+(this.name || config.name || 'node-scripts')
+			value: config.logpath || `${libPath}/Logs/`+(this.name || config.name || 'node-scripts')
 		},
 
 		/**


### PR DESCRIPTION
allow to run under logged in user, storing conf and logs in `~/Library/` vs `/Library/`