### PR TITLE
add execPath and nodeOptions in service config

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -251,6 +251,17 @@ var daemon = function(config) {
     },
 
     /**
+     * @cfg {string} [nodeOptions='--harmony']
+     * Options to be passed to the node process.
+     */
+    nodeOptions: {
+      enumerable: true,
+      writable: false,
+      configurable: false,
+      value: config.nodeOptions || '--harmony'
+    },
+
+    /**
      * @cfg {Boolean} [abortOnError=false]
      * Setting this to `true` will force the process to exit if it encounters an error that stops the node.js script from running.
      * This does not mean the process will stop if the script throws an error. It will only abort if the
@@ -330,7 +341,9 @@ var daemon = function(config) {
 						}
 						// Build the plist file
 						var args = [
-							me.execPath,'--harmony',wrapper,
+							me.execPath,
+              me.nodeOptions,
+              wrapper,
 							'-f',me.script,
 							'-l',me.outlog,
 							'-e',me.errlog,

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -213,6 +213,19 @@ var daemon = function(config) {
 			value: config.logpath || homedir + '/Library/Logs/' + (this.name || config.name || 'node-scripts')
 		},
 
+    /**
+     * @cfg {String} execPath
+     * The absolute path to the executable that will launch the script.
+     * If omitted process.execPath is used.
+     */
+    execPath: {
+      enumerable: true,
+      writable: true,
+      configurable: false,
+      value: config.execPath !== undefined ? require('path').resolve(config.execPath) : process.execPath
+    },
+
+
 		/**
      * @cfg {Number} [maxRetries=null]
      * The maximum number of restart attempts to make before the service is considered non-responsive/faulty.
@@ -317,7 +330,7 @@ var daemon = function(config) {
 						}
 						// Build the plist file
 						var args = [
-							process.execPath,'--harmony',wrapper,
+							me.execPath,'--harmony',wrapper,
 							'-f',me.script,
 							'-l',me.outlog,
 							'-e',me.errlog,


### PR DESCRIPTION
This PR is to add a similar functionality as in node-windows for execPath and  nodeOptions,
As a developer, I should be able to configure the executable that will launch a Service with Custom Args (not only --harmony)

This is useful in a packaged application since the electron executable by default is all the app itself, for example `/Applications/MyApp.app/Contents/MacOS/MyApp`, if this executable tries to install the script will run all the application. 
So what we are doing is to include the Electron binary or Node Binary, and use it in execPath in node-windows, that works well.
The problem is when we tried to use the same for node-mac.

Reading the contribution guidelines...
`Contributions must be cross-platform compatible... node-windows/mac/linux share a common API.`

This change will help to close the gap between the available configuration options in windows and mac.

Tested locally in my mac, with this change the plist passes the correct execPath provided in the config.
```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
  <dict>
    <key>Title</key>
    <string>myappservice</string>
    <key>Label</key>
    <string>myappservice</string>
    <key>ProgramArguments</key>
    <array>
      <string>/Applications/MyApp.app/Contents/Resources/electron/dist/Electron.app/Contents/MacOS/Electron</string>
```